### PR TITLE
Define spec-writer input/output contract

### DIFF
--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -7,12 +7,34 @@ model: inherit
 
 You are a technical specification writer. Given research findings and interview answers, produce a clear, actionable implementation spec.
 
-## Input
+## Input Format
 
-You'll receive:
-1. **Research findings** - Structured output from codebase-explorer
-2. **Interview Q&A** - User's answers to clarifying questions
-3. **Spec metadata** - Topic, issue ID, output path, template
+You'll receive a structured prompt with these sections:
+
+```
+## Research Findings
+
+<structured markdown from codebase-explorer>
+
+## Interview Q&A
+
+**Q1**: <question asked>
+**A1**: <user's answer>
+
+**Q2**: <question asked>
+**A2**: <user's answer>
+
+...
+
+## Spec Metadata
+
+- **Topic**: <feature or task name>
+- **Issue**: <issue ID or N/A>
+- **Output Path**: </absolute/path/to/spec.md>
+- **Date**: <YYYY-MM-DD>
+```
+
+All sections are required. Write the spec to the exact path specified in Output Path.
 
 ## Output
 

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -96,12 +96,32 @@ Tell the user "I have enough to write the spec" when ready.
 
 Use the Task tool to invoke the **spec-writer** subagent.
 
-Provide:
-1. **Research findings** from Step 4
-2. **Interview Q&A** from Step 5
-3. **Metadata**: topic, issue ID, output path (`<git-root>/<specsLocation>/<filename>.md`)
+Provide the prompt in this exact format:
 
-The subagent will write the spec file directly.
+```
+## Research Findings
+
+<paste structured findings from Step 4>
+
+## Interview Q&A
+
+**Q1**: <first question you asked>
+**A1**: <user's answer>
+
+**Q2**: <second question you asked>
+**A2**: <user's answer>
+
+<continue for all Q&A>
+
+## Spec Metadata
+
+- **Topic**: <topic name>
+- **Issue**: <issue ID or N/A>
+- **Output Path**: <git-root>/<specsLocation>/<filename>.md
+- **Date**: <YYYY-MM-DD>
+```
+
+The subagent will write the spec file directly to the Output Path.
 
 **Naming convention**: `<issue-id>-<topic>.md` or `<topic>.md`
 


### PR DESCRIPTION
## Summary

Adds explicit input format to spec-writer subagent and updates the spec command to match.

## Changes

**agents/spec-writer.md:**
- Replaced vague "you'll receive" with explicit input format
- Shows exact structure: Research Findings, Interview Q&A, Spec Metadata
- Clarifies all sections are required

**commands/spec.md:**
- Updated Step 6 to provide input in matching format
- Shows how to structure Q&A pairs
- Includes all required metadata fields

## Input Format

```
## Research Findings
<structured markdown from codebase-explorer>

## Interview Q&A
**Q1**: <question>
**A1**: <answer>
...

## Spec Metadata
- **Topic**: <name>
- **Issue**: <ID or N/A>
- **Output Path**: </path/to/spec.md>
- **Date**: <YYYY-MM-DD>
```

Closes #3