### PR TITLE
Structure interview Q&A by rounds for spec-writer handoff

### DIFF
--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -18,13 +18,17 @@ You'll receive a structured prompt with these sections:
 
 ## Interview Q&A
 
-**Q1**: <question asked>
-**A1**: <user's answer>
+### Core Decisions
+**Q**: <question about fundamental approach>
+**A**: <user's answer>
 
-**Q2**: <question asked>
-**A2**: <user's answer>
+### Edge Cases & Tradeoffs
+**Q**: <question about error handling, edge cases>
+**A**: <user's answer>
 
-...
+### Scope & Boundaries
+**Q**: <question about what's in/out of scope>
+**A**: <user's answer>
 
 ## Spec Metadata
 
@@ -35,6 +39,11 @@ You'll receive a structured prompt with these sections:
 ```
 
 All sections are required. Write the spec to the exact path specified in Output Path.
+
+**Mapping Q&A to spec sections:**
+- Core Decisions → Decisions, Approach
+- Edge Cases & Tradeoffs → Edge Cases, Risks & Considerations
+- Scope & Boundaries → Out of Scope, Implementation Steps
 
 ## Output
 

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -105,13 +105,17 @@ Provide the prompt in this exact format:
 
 ## Interview Q&A
 
-**Q1**: <first question you asked>
-**A1**: <user's answer>
+### Core Decisions
+**Q**: <question from Round 1>
+**A**: <user's answer>
 
-**Q2**: <second question you asked>
-**A2**: <user's answer>
+### Edge Cases & Tradeoffs
+**Q**: <question from Round 2>
+**A**: <user's answer>
 
-<continue for all Q&A>
+### Scope & Boundaries
+**Q**: <question from Round 3>
+**A**: <user's answer>
 
 ## Spec Metadata
 


### PR DESCRIPTION
## Summary

Groups interview Q&A into round-based sections that map to spec output sections.

## Changes

Updates the Q&A format from flat list to categorized rounds:

```
## Interview Q&A

### Core Decisions
**Q**: <question from Round 1>
**A**: <user's answer>

### Edge Cases & Tradeoffs
**Q**: <question from Round 2>
**A**: <user's answer>

### Scope & Boundaries
**Q**: <question from Round 3>
**A**: <user's answer>
```

## Mapping

| Interview Round | Spec Sections |
|-----------------|---------------|
| Core Decisions | Decisions, Approach |
| Edge Cases & Tradeoffs | Edge Cases, Risks & Considerations |
| Scope & Boundaries | Out of Scope, Implementation Steps |

Closes #4