### PR TITLE
Add error handling for subagent failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins by Vieko",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "plugins": [
     {
       "name": "bonfire",
       "source": "./",
       "description": "AI forgets everything between sessions. Bonfire fixes that.",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "author": {
         "name": "Vieko Franetovic"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bonfire",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AI forgets everything between sessions. Bonfire fixes that.",
   "author": {
     "name": "Vieko Franetovic",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.2] - 2026-01-03
+
+### Added
+
+- **Subagent error handling** - Graceful fallbacks when subagents fail
+  - Progress messages: "Researching codebase...", "Writing spec...", etc.
+  - Output validation: Checks subagent returned expected structure
+  - Fallback behavior: Falls back to in-context operation on failure
+  - File verification: Confirms spec files were actually written
+  - Pattern follows established "warn + offer alternative" convention
+
+### Changed
+
+- `/bonfire:spec` - Added research validation and spec verification sections
+- `/bonfire:document` - Added exploration validation section
+- `/bonfire:review` - Added review validation section
+
 ## [0.8.1] - 2026-01-03
 
 ### Changed

--- a/commands/document.md
+++ b/commands/document.md
@@ -25,6 +25,8 @@ If no topic provided, ask the user what they want documented.
 
 ## Step 4: Explore the Codebase (Subagent)
 
+**Progress**: Tell the user "Exploring codebase for [TOPIC]..."
+
 Use the Task tool to invoke the **codebase-explorer** subagent for research.
 
 Provide a research directive:
@@ -45,6 +47,30 @@ Return structured findings with file paths and brief descriptions.
 **Wait for the subagent to return findings** before proceeding.
 
 The subagent runs in isolated context (haiku model, fast), preserving main context for writing.
+
+### Exploration Validation
+
+After the subagent returns, validate the response:
+
+**Valid response contains at least one of:**
+- `## Architecture` or `## Patterns Found` with content
+- `## Key Files` with entries
+- `## Flow` or `## Gotchas` with items
+
+**On valid response**: Proceed to Step 5.
+
+**On invalid/empty response**:
+1. Warn user: "Codebase exploration returned limited results. I'll research directly."
+2. Fall back to in-context research:
+   - `Glob("**/*[topic-related]*")` to find relevant files
+   - `Grep("topic-keywords")` to find implementations
+   - Read identified files
+3. Continue to Step 5 with in-context findings.
+
+**On subagent failure** (timeout, error):
+1. Warn user: "Subagent exploration failed. Continuing with direct research."
+2. Perform in-context research as above.
+3. Continue to Step 5.
 
 ## Step 5: Create Documentation
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -23,6 +23,8 @@ Based on $ARGUMENTS:
 
 ## Step 3: Run Review (Subagent)
 
+**Progress**: Tell the user "Reviewing work for blindspots and gaps..."
+
 Use the Task tool to invoke the **work-reviewer** subagent.
 
 Provide the review context:
@@ -46,6 +48,33 @@ Return categorized findings with severity and effort estimates.
 **Wait for the subagent to return findings** before proceeding.
 
 The subagent runs in isolated context (sonnet model), preserving main context for action decisions.
+
+### Review Validation
+
+After the subagent returns, validate the response:
+
+**Valid response contains:**
+- `## Summary` with finding counts
+- At least one of: `## Fix Now`, `## Needs Spec`, or `## Create Issues`
+
+**On valid response**: Proceed to Step 4.
+
+**On partial response** (missing categories but has findings):
+1. Warn user: "Review returned partial results. Some categories may be missing."
+2. Present available findings.
+3. Continue to Step 5.
+
+**On invalid/empty response**:
+1. Warn user: "Review subagent returned no findings. I'll review directly."
+2. Fall back to in-context review:
+   - Read changed files from git diff
+   - Analyze for common issues (missing tests, error handling, etc.)
+   - Check for TODOs and incomplete implementations
+3. Present in-context findings using the same format.
+
+**On subagent failure** (timeout, error):
+1. Warn user: "Review subagent failed. Continuing with direct review."
+2. Perform in-context review as above.
 
 ## Step 4: Session Scripts Review
 


### PR DESCRIPTION
## Summary

- Add progress messages to inform users during subagent operations
- Add output validation to check subagents returned expected structure
- Add fallback behavior to continue with in-context operation on failure
- Add spec file verification to confirm files were actually written
- Bump version to 0.8.2

## Changes

| File | Change |
|------|--------|
| `commands/spec.md` | Progress + research validation + spec verification |
| `commands/document.md` | Progress + exploration validation |
| `commands/review.md` | Progress + review validation |

## Test plan

- [ ] Run `/bonfire:spec` and verify progress messages appear
- [ ] Run `/bonfire:document` and verify progress messages appear
- [ ] Run `/bonfire:review` and verify progress messages appear
- [ ] Verify fallback behavior documented (hard to force failures)

Closes #13