### PR TITLE
Make Round 3 (Testing & Scope) required in spec interview

### DIFF
--- a/commands/spec.md
+++ b/commands/spec.md
@@ -99,24 +99,22 @@ Example questions:
 - "I found [potential conflict]. How should we handle it?"
 - "[Approach A] is simpler but [tradeoff]. [Approach B] is more complex but [benefit]. Preference?"
 
-### Round 3: Scope & Boundaries (if needed)
+### Round 3: Testing & Scope (Required)
 
-If scope is still unclear:
-- What's explicitly out of scope?
-- MVP vs full implementation?
-- Dependencies on other work?
+Always ask about testing and scope, even if user seems ready to proceed:
 
-### Continue Until Complete
+**Testing** (must ask one):
+- "What's the testing approach? Unit tests, integration tests, manual testing, or skip tests for MVP?"
+- "Should this include tests? If so, what should be covered?"
 
-Keep asking rounds of questions until you have clarity on:
-- [ ] Core approach and architecture
-- [ ] Key technical decisions
-- [ ] Error handling strategy
-- [ ] Edge cases covered
-- [ ] Testing approach
-- [ ] Scope boundaries
+**Scope** (must ask one):
+- "What's explicitly out of scope for this implementation?"
+- "MVP vs full implementation - any features to defer?"
 
-Tell the user "I have enough to write the spec" when ready.
+Example combined question:
+- "Two quick questions: (1) Testing approach for this feature? (2) Anything explicitly out of scope?"
+
+**Do not skip Round 3.** These questions take 30 seconds and prevent spec gaps.
 
 ## Step 6: Write the Spec (Subagent)
 


### PR DESCRIPTION
## Summary

- Makes interview Round 3 required instead of optional
- Adds explicit testing and scope question examples
- Removes validation step that wasn't being followed

## Background

Issue #16 aimed to add interview completion validation. Testing revealed that self-validation steps are skipped - Claude proceeds directly without checking coverage.

## What Changed

**Before**: Round 3 was "(if needed)" with no testing questions
**After**: Round 3 is "(Required)" with explicit testing and scope questions

The spec-writer template fills any remaining gaps, so specs still include Testing Strategy even if not discussed.

## Test Results

Tested on GTM with `/bonfire:spec GTMENG-405`:
- ✅ Scope question was asked
- ⚠️ Testing question still sometimes skipped (spec-writer compensates)

## Follow-up

Created #19 to experiment with stronger validation approaches.

## Test plan

- [x] Run `/bonfire:spec` on GTM project
- [x] Verify Round 3 questions are asked
- [x] Verify spec includes Testing Strategy section