### PR TITLE
Add partial file write detection to spec verification

### DIFF
--- a/commands/spec.md
+++ b/commands/spec.md
@@ -157,25 +157,47 @@ The subagent will write the spec file directly to the Output Path.
 
 ### Spec Verification
 
-After the spec-writer subagent returns:
+After the spec-writer subagent returns, verify the spec is complete.
 
-1. **Verify file exists**: Read the spec file at `<git-root>/<specsLocation>/<filename>.md`
+**Key sections to check** (lenient - only these 4):
+- `## Overview`
+- `## Decisions`
+- `## Implementation Steps`
+- `## Edge Cases`
 
-2. **On success** (file exists with content):
-   - Tell user: "Spec written successfully."
-   - Proceed to Step 7 (Link to Session Context).
+**Verification steps:**
 
-3. **On failure** (file missing or empty):
-   - Warn user: "Spec file wasn't written correctly. Writing directly..."
-   - Write the spec yourself using the Write tool with:
-     - Research findings from Step 4
-     - Interview answers from Step 5
-     - Spec template from spec-writer.md
+1. **Read the spec file** at `<git-root>/<specsLocation>/<filename>.md`
+
+2. **If file missing or empty**:
+   - Warn user: "Spec file wasn't written. Writing directly..."
+   - Write the spec yourself using the Write tool
+   - Run verification again on the written file
+
+3. **If file exists, check for key sections**:
+   - Scan content for the 4 section headers above
+   - Track which sections are present/missing
+
+4. **If all 4 sections present**:
+   - Tell user: "Spec written and verified (4/4 key sections present)."
    - Proceed to Step 7.
 
-4. **On subagent failure** (timeout, error):
-   - Warn user: "Spec writer failed. Writing spec directly..."
-   - Write the spec yourself as above.
+5. **If 1-3 sections missing** (partial write):
+   - Warn user: "Spec appears incomplete. Missing sections: [list missing]"
+   - Show which sections ARE present
+   - Ask: "Proceed with partial spec, retry write, or abort?"
+   - **Proceed**: Continue to Step 7
+   - **Retry**: Re-invoke spec-writer subagent with same input, then verify again
+   - **Abort**: Stop and inform user the incomplete spec file remains at path
+
+6. **If all sections missing but has content**:
+   - Treat as invalid format, trigger fallback write
+   - Write the spec yourself, then verify the written file
+
+**On subagent failure** (timeout, error):
+- Warn user: "Spec writer failed. Writing spec directly..."
+- Write the spec yourself using the Write tool
+- Run verification on the written file
 
 ## Step 7: Link to Session Context
 


### PR DESCRIPTION
## Summary

Enhances spec verification to detect incomplete/truncated specs, not just missing files.

## Problem

Current verification only checks if file exists with content. A partial spec (e.g., subagent write interrupted mid-file) would pass verification but be unusable.

## Solution

Check for 4 key sections (lenient validation):
- `## Overview`
- `## Decisions`
- `## Implementation Steps`
- `## Edge Cases`

**On partial detection:**
1. Warn user with specific missing sections
2. Offer choices: proceed anyway, retry, or abort
3. Same validation applies to fallback writes

## Changes

- Added key sections definition
- Added section-based validation after file read
- Added partial detection flow with user choices
- Fallback writes now run through same verification
- Updated success message: "Spec written and verified (4/4 key sections present)"

Closes #17

## Test plan

- [ ] Run `/bonfire:spec` and verify success message shows "4/4 key sections"
- [ ] Manually create a spec missing sections, verify partial detection triggers
- [ ] Verify retry and abort options work as expected