### PR TITLE
Add PostToolUse hook links and interview progress messages

### DIFF
--- a/commands/document.md
+++ b/commands/document.md
@@ -128,6 +128,10 @@ flowchart TD
 - [Code reference]: `path/to/file.ts`
 ```
 
+## Formatting Tip
+
+If the generated doc has inconsistent formatting, configure a PostToolUse hook to auto-format files after writes. See [PostToolUse Formatter Hook](../docs/post-tool-use-formatter-hook.md).
+
 ## Step 6: Link to Session Context
 
 Add a reference to the doc in `<git-root>/.bonfire/index.md` under Key Resources or Notes.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -75,9 +75,13 @@ After the subagent returns, validate the response:
 
 ## Step 5: Interview Phase (Main Context)
 
+**Progress**: Tell the user "Starting interview (3 rounds: core decisions, edge cases, testing & scope)..."
+
 Using the research findings, interview the user with **informed questions** via AskUserQuestion.
 
 ### Round 1: Core Decisions
+
+**Progress**: "Round 1/3: Core decisions..."
 
 Ask about fundamental approach based on patterns found:
 
@@ -87,6 +91,8 @@ Example questions (adapt based on actual findings):
 - "I see [Library] is used for [purpose]. Should we use it here or try [Alternative]?"
 
 ### Round 2: Edge Cases & Tradeoffs
+
+**Progress**: "Round 2/3: Edge cases and tradeoffs..."
 
 Based on Round 1 answers and research, ask about:
 - Error handling approach
@@ -100,6 +106,8 @@ Example questions:
 - "[Approach A] is simpler but [tradeoff]. [Approach B] is more complex but [benefit]. Preference?"
 
 ### Round 3: Testing & Scope (Required)
+
+**Progress**: "Round 3/3: Testing and scope (final round)..."
 
 Always ask about testing and scope, even if user seems ready to proceed:
 
@@ -228,6 +236,10 @@ Read the generated spec and present a summary. Ask if user wants to:
 - "I found `UserService` uses repository pattern but `OrderService` uses direct DB access. Which approach?"
 - "The `auth` middleware validates JWT but doesn't check permissions. Should this feature add permission checks or assume auth is enough?"
 - "There's a `BaseController` with shared logic. Extend it or keep this feature standalone?"
+
+## Formatting Tip
+
+If the generated spec has inconsistent formatting, configure a PostToolUse hook to auto-format files after writes. See [PostToolUse Formatter Hook](../docs/post-tool-use-formatter-hook.md).
 
 ## Spec Lifecycle
 


### PR DESCRIPTION
## Summary

Addresses nice-to-have improvements from review (#18).

## Implemented

### 1. Link PostToolUse hook from file-writing commands ✅
- Added "Formatting Tip" section to `spec.md` and `document.md`
- Links to `docs/post-tool-use-formatter-hook.md`

### 2. Add progress messaging to interview phase ✅
- Added progress indicator at start of Step 5: "Starting interview (3 rounds...)"
- Added round indicators before each round: "Round 1/3: Core decisions..."

## Investigated but not implemented

### 3. Extract fallback research logic ❌
Each command's fallback is context-specific:
- `spec.md`: `Glob("**/*.{ts,js,py,go}")` for code patterns
- `document.md`: `Glob("**/*[topic-related]*")` for topic files
- `review.md`: `git diff` for changed files

Extracting would add abstraction without meaningful benefit.

### 4. Configurable timeout for subagents ❌
Task tool handles timeouts internally. Adding config would require Task tool changes.

Closes #18

## Test plan

- [x] Verify Formatting Tip sections appear in spec.md and document.md
- [x] Verify progress messages added to interview rounds