### PR TITLE
Add doc-writer subagent and resumable subagent support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins by Vieko",
-    "version": "0.8.2"
+    "version": "0.9.0"
   },
   "plugins": [
     {
       "name": "bonfire",
       "source": "./",
-      "description": "AI forgets everything between sessions. Bonfire fixes that.",
-      "version": "0.8.2",
+      "description": "AI forgets everything between sessions. Bonfire remembers.",
+      "version": "0.9.0",
       "author": {
         "name": "Vieko Franetovic"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bonfire",
-  "version": "0.8.2",
-  "description": "AI forgets everything between sessions. Bonfire fixes that.",
+  "version": "0.9.0",
+  "description": "AI forgets everything between sessions. Bonfire remembers.",
   "author": {
     "name": "Vieko Franetovic",
     "email": "hello@vieko.dev",
@@ -23,6 +23,7 @@
   "agents": [
     "./agents/codebase-explorer.md",
     "./agents/spec-writer.md",
-    "./agents/work-reviewer.md"
+    "./agents/work-reviewer.md",
+    "./agents/doc-writer.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-01-03
+
+### Added
+
+- **doc-writer subagent** - Writes documentation in isolated context (#5)
+  - Model: inherit (same as spec-writer)
+  - Tools: Read, Write
+  - Input: Research findings + topic metadata
+  - Output: Complete documentation file
+  - `/bonfire:document` now uses doc-writer after codebase-explorer
+  - Added doc verification (checks 4 key sections: Overview, Key Files, How It Works, Gotchas)
+
+- **Resumable subagent support** - Multi-pass analysis for large codebases (#6)
+  - All subagent-using commands now support resume via Task tool's `resume` parameter
+  - When to offer: "X additional items omitted", partial coverage, user requests deeper analysis
+  - Up to 3 passes maximum per exploration/review
+  - Findings are merged across passes
+
+### Changed
+
+- `/bonfire:document` - Now uses two subagents (explorer → writer) matching spec pattern
+- `/bonfire:spec` - Added resumable exploration section
+- `/bonfire:review` - Added resumable review section
+- Updated plugin.json to include doc-writer agent
+
 ## [0.8.2] - 2026-01-03
 
 ### Added
@@ -23,7 +48,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Updated plugin description to match README: "AI forgets everything between sessions. Bonfire fixes that."
+- Updated plugin description to match README: "AI forgets everything between sessions. Bonfire remembers."
 
 ## [0.8.0] - 2026-01-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Main Context (user interaction)
 |-------|-------|---------|
 | `codebase-explorer` | haiku | Fast pattern/architecture research |
 | `spec-writer` | inherit | Synthesize findings + interview → spec |
+| `doc-writer` | inherit | Synthesize findings → documentation |
 | `work-reviewer` | sonnet | Strategic review, categorized findings |
 
 ## Development Notes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="bonfire.png" alt="Bonfire" width="200">
 </p>
 
-Your AI coding partner forgets everything between conversations. Bonfire fixes that.
+Your AI coding partner forgets everything between conversations. Bonfire remembers.
 
 ```bash
 claude plugin marketplace add vieko/bonfire

--- a/agents/doc-writer.md
+++ b/agents/doc-writer.md
@@ -1,0 +1,110 @@
+---
+name: doc-writer
+description: Synthesizes research findings into reference documentation. Use after codebase exploration to write docs in isolated context.
+tools: Read, Write
+model: inherit
+---
+
+You are a technical documentation writer. Given research findings about a codebase topic, produce clear, useful reference documentation.
+
+## Input Format
+
+You'll receive a structured prompt with these sections:
+
+```
+## Research Findings
+
+<structured markdown from codebase-explorer>
+
+## Doc Metadata
+
+- **Topic**: <what to document>
+- **Output Path**: </absolute/path/to/doc.md>
+- **Date**: <YYYY-MM-DD>
+```
+
+All sections are required. Write the documentation to the exact path specified in Output Path.
+
+**Mapping findings to doc sections:**
+- Architecture/Patterns → Architecture, How It Works
+- Key Files → Key Files table
+- Flow → How It Works (step-by-step)
+- Gotchas → Gotchas section
+- Constraints → noted throughout where relevant
+
+## Output
+
+Write a complete documentation file to the specified path. The doc must be:
+- **Clear** - Understandable by someone new to the codebase
+- **Grounded** - Based on discovered patterns, not assumptions
+- **Useful** - Answers "how does this work?" and "where do I look?"
+
+## Doc Template
+
+```markdown
+# [TOPIC]
+
+## Overview
+
+[What this is, why it exists, when you'd interact with it]
+
+## Architecture
+
+[How it's structured - components, layers, key relationships]
+
+```mermaid
+flowchart TD
+    A[Component A] --> B[Component B]
+    B --> C[Component C]
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `path/to/file.ts` | [What it does] |
+| `path/to/other.ts` | [What it does] |
+
+## How It Works
+
+[Step-by-step flow, data transformations, control flow]
+
+1. **Step one**: [What happens]
+2. **Step two**: [What happens]
+3. **Step three**: [What happens]
+
+## Usage Examples
+
+[Code examples, CLI commands, common operations]
+
+```typescript
+// Example usage
+```
+
+## Gotchas
+
+- **[Issue]**: [Why it matters, how to avoid]
+- **[Edge case]**: [What to watch out for]
+
+## Related
+
+- [Related doc](other-doc.md)
+- [Code reference]: `path/to/file.ts`
+```
+
+## Rules
+
+1. **Ground in research** - Reference actual files and patterns discovered
+2. **Be specific** - Use real file paths, not placeholders
+3. **Don't invent** - If something wasn't in findings, don't guess
+4. **Keep it scannable** - Headers, tables, and lists over prose
+5. **Include code paths** - Always show where to look in the codebase
+
+## Quality Checklist
+
+Before finishing, verify:
+- [ ] Overview explains what and why
+- [ ] Key files table has real paths from research
+- [ ] How It Works section is step-by-step
+- [ ] Gotchas from research are captured
+- [ ] Mermaid diagram accurately reflects architecture (if included)

--- a/commands/review.md
+++ b/commands/review.md
@@ -76,6 +76,28 @@ After the subagent returns, validate the response:
 1. Warn user: "Review subagent failed. Continuing with direct review."
 2. Perform in-context review as above.
 
+### Resumable Review (Large Changes)
+
+For large changesets, review may need multiple passes. The Task tool returns an `agentId` you can use to resume.
+
+**When to offer resume:**
+- Review covers many files and user wants deeper analysis of specific area
+- Findings mention "additional items omitted" or suggest areas need more attention
+- User wants to focus review on specific aspect (e.g., "look more at tests")
+
+**To resume review:**
+1. Tell user: "Review covered [X]. Want deeper analysis of [specific area]?"
+2. If yes, re-invoke work-reviewer with the `resume` parameter:
+   - Pass the agentId from the previous invocation
+   - Provide a focused directive: "Continue review focusing on: [specific area]."
+3. Merge findings from resumed review with previous findings.
+4. Repeat if needed, up to 3 passes maximum.
+
+**Example multi-pass scenario:**
+- Pass 1: General review → finds 5 issues, notes "test coverage not analyzed"
+- Pass 2 (resume): "Continue review focusing on: test coverage" → finds 3 more test gaps
+- Merge: Combined findings give complete picture
+
 ## Step 4: Session Scripts Review
 
 Check if `<git-root>/.bonfire/scripts/` contains any files.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -73,6 +73,28 @@ After the subagent returns, validate the response:
 2. Perform in-context research as above.
 3. Continue to Step 5.
 
+### Resumable Exploration (Large Codebases)
+
+For very large codebases, exploration may need multiple passes. The Task tool returns an `agentId` you can use to resume.
+
+**When to offer resume:**
+- Subagent returns with "X additional items omitted" notes
+- Findings cover only part of the codebase (e.g., backend but not frontend)
+- User asks for deeper exploration of a specific area
+
+**To resume exploration:**
+1. Tell user: "Exploration found [X] but there's more to explore. Continue exploring [specific area]?"
+2. If yes, re-invoke codebase-explorer with the `resume` parameter:
+   - Pass the agentId from the previous invocation
+   - Provide a refined directive: "Continue exploring: [specific area]. Focus on [what to find]."
+3. Merge findings from resumed exploration with previous findings.
+4. Repeat if needed, up to 3 passes maximum.
+
+**Example multi-pass scenario:**
+- Pass 1: "Research authentication" → finds auth middleware, auth service
+- Pass 2 (resume): "Continue exploring: authorization rules" → finds permissions, role checks
+- Merge: Combined findings inform better interview questions
+
 ## Step 5: Interview Phase (Main Context)
 
 **Progress**: Tell the user "Starting interview (3 rounds: core decisions, edge cases, testing & scope)..."


### PR DESCRIPTION
## Summary

- **doc-writer subagent (#5)**: New subagent for writing documentation in isolated context, matching the spec-writer pattern
- **Resumable subagents (#6)**: All subagent-using commands now support multi-pass analysis via Task tool's `resume` parameter
- **Tagline update**: "Bonfire fixes that" → "Bonfire remembers"

## Changes

### New Files
- `agents/doc-writer.md` - Synthesizes research findings into documentation

### Modified Commands
- `commands/document.md` - Now uses explorer → writer flow with doc verification
- `commands/spec.md` - Added resumable exploration section
- `commands/review.md` - Added resumable review section

### Config/Docs
- Bumped version to 0.9.0
- Updated CHANGELOG.md, CLAUDE.md
- Updated tagline in plugin.json, marketplace.json, README.md

## Test plan

- [ ] Run `/bonfire:document <topic>` on a test project
- [ ] Verify doc-writer subagent is invoked
- [ ] Verify doc verification checks 4 key sections
- [ ] Test fallback when subagent fails