### PR TITLE
Replace Linear MCP with linear-cli

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins by Vieko",
-    "version": "0.9.1"
+    "version": "0.9.2"
   },
   "plugins": [
     {
       "name": "bonfire",
       "source": "./",
       "description": "AI forgets everything between sessions. Bonfire remembers.",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "author": {
         "name": "Vieko Franetovic"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bonfire",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI forgets everything between sessions. Bonfire remembers.",
   "author": {
     "name": "Vieko Franetovic",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.2] - 2026-01-05
+
+### Changed
+
+- **Replaced Linear MCP with linear-cli** - Lower context cost, better developer experience
+  - Install: `brew install schpet/tap/linear` then `linear auth`
+  - Commands now use `Bash(linear:*)` instead of `mcp__linear__*`
+  - ~5x less context (~2KB vs ~10KB) with on-demand discovery via `--help`
+  - Bonus: git integration (branch creation from issues)
+  - See [linear-cli](https://github.com/schpet/linear-cli) for full documentation
+
+### Migration from 0.9.1
+
+If you use Linear integration:
+1. Install linear-cli: `brew install schpet/tap/linear`
+2. Authenticate: `linear auth`
+3. (Optional) Remove Linear MCP from your Claude Code config
+
 ## [0.9.1] - 2026-01-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ All settings are stored in `.bonfire/config.json` per-project:
 - **specsLocation**: Where specs are saved (.bonfire/specs/ or specs/)
 - **docsLocation**: Where docs are saved (.bonfire/docs/ or docs/)
 - **gitStrategy**: How .bonfire/ is handled in git (ignore-all, hybrid, commit-all)
-- **linearEnabled**: Enable Linear MCP integration (true/false)
+- **linearEnabled**: Enable Linear integration via linear-cli (true/false)
 
 ## Subagent Architecture
 

--- a/README.md
+++ b/README.md
@@ -117,11 +117,14 @@ Change anytime with `/bonfire:configure`.
 
 If you use Linear for issue tracking:
 
-1. Install [Linear MCP](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-linear)
-2. Enable via `/bonfire:configure`
-3. Reference issues by ID: `ENG-123`
+1. Install [linear-cli](https://github.com/schpet/linear-cli) (`brew install schpet/tap/linear`)
+2. Authenticate: `linear auth`
+3. Enable via `/bonfire:configure`
+4. Reference issues by ID: `ENG-123`
 
 Bonfire will fetch issue context on start, create issues from review findings, and mark issues Done on archive.
+
+**Why linear-cli over Linear MCP?** Lower context cost (~2KB vs ~10KB), on-demand discovery via `--help`, and git integration as a bonus.
 
 ## Proactive Skills
 
@@ -137,7 +140,7 @@ And suggests archiving when you merge PRs or mention shipping.
 - [Claude Code CLI](https://claude.ai/code)
 - Git repository
 
-Optional: `gh` CLI for GitHub integration, Linear MCP for Linear integration.
+Optional: `gh` CLI for GitHub integration, [linear-cli](https://github.com/schpet/linear-cli) for Linear integration.
 
 ## Recommended: Auto-Formatting Hook
 

--- a/commands/archive.md
+++ b/commands/archive.md
@@ -1,6 +1,6 @@
 ---
 description: Archive completed session work
-allowed-tools: Bash(git:*), Read, Write, Glob, mcp__linear__*
+allowed-tools: Bash(git:*), Bash(linear:*), Read, Write, Glob
 model: haiku
 ---
 
@@ -90,13 +90,17 @@ Read `<git-root>/.bonfire/config.json` and check `linearEnabled`.
 1. Check if archived work references a Linear issue (look in session context for `[A-Z]+-[0-9]+` pattern)
 2. If Linear issue found, ask user: "Mark Linear issue [ISSUE-ID] as Done?"
 3. If user confirms:
-   - Use Linear MCP `linear_update_issue` tool with:
-     - `id`: The issue ID (e.g., `ENG-123`)
-     - `status`: Set to "Done" or completed state
-   - Optionally use `linear_add_comment` to add link to archive/PR
+   - Use linear-cli to update the issue:
+     ```bash
+     linear issue update ENG-123 --state "Done"
+     ```
+   - Optionally add a comment with link to archive/PR:
+     ```bash
+     linear issue comment add ENG-123 -b "Archived: [link]"
+     ```
 4. On failure: Warn user - "Couldn't update Linear issue. You may need to update it manually."
 
-Note: Tool names may vary by Linear MCP implementation.
+Note: Run `linear issue update --help` to see available options.
 
 **If `linearEnabled` is false or not set**: Skip this step.
 

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -37,9 +37,9 @@ Use AskUserQuestion to ask configuration questions (4 questions, one round):
    - hybrid - Commit docs/specs, keep notes private
    - commit-all - Share everything with team
 
-4. "Enable Linear MCP integration?" (Header: "Linear")
+4. "Enable Linear integration?" (Header: "Linear")
    - No (Default) - Skip Linear integration
-   - Yes - Fetch/create Linear issues (requires Linear MCP)
+   - Yes - Fetch/create Linear issues (requires linear-cli)
 
 ## Step 5: Update Config
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Review work for blindspots, gaps, and improvements
-allowed-tools: Bash(git:*), Bash(gh:*), Read, Write, Task, mcp__linear__*
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(linear:*), Read, Write, Task
 ---
 
 # Review Work
@@ -149,14 +149,14 @@ gh issue create --title "Finding title" --body "Finding details"
 ```
 
 **Linear Issue Creation (if enabled):**
-1. Use Linear MCP `linear_create_issue` tool with:
-   - `title`: Finding summary
-   - `description`: Finding details with context
-   - `teamId`: Infer from session context if available, otherwise use default
+1. Use linear-cli to create the issue:
+   ```bash
+   linear issue create --title "Finding title" --description "Finding details"
+   ```
 2. On success: Return issue URL/ID
 3. On failure: Warn user, offer to create GitHub issue instead
 
-Note: Tool names may vary by Linear MCP implementation.
+Note: Run `linear issue create --help` to see available options (team, priority, labels, etc.).
 
 **For each created issue:**
 - Record the issue ID and URL

--- a/commands/start.md
+++ b/commands/start.md
@@ -1,6 +1,6 @@
 ---
 description: Start a new session - reads context and scaffolds .bonfire/ if needed
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(mkdir:*), Read, Write, Glob, AskUserQuestion, mcp__linear__*
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(mkdir:*), Bash(linear:*), Read, Write, Glob, AskUserQuestion
 model: haiku
 ---
 
@@ -33,9 +33,9 @@ Check if `<git-root>/.bonfire/index.md` exists.
       - hybrid - Commit docs/specs, keep notes private
       - commit-all - Share everything with team
 
-   4. "Enable Linear MCP integration?" (Header: "Linear")
+   4. "Enable Linear integration?" (Header: "Linear")
       - No (Default) - Skip Linear integration
-      - Yes - Fetch/create Linear issues (requires Linear MCP)
+      - Yes - Fetch/create Linear issues (requires linear-cli)
 
 3. Create the directory structure based on user choices:
 
@@ -223,12 +223,15 @@ First, read `<git-root>/.bonfire/config.json` and check `linearEnabled`.
 **If `linearEnabled` is false or not set**: Skip Linear, treat as ad-hoc task.
 
 **If `linearEnabled` is true**:
-1. Use Linear MCP `linear_search_issues` tool to find the issue by ID (e.g., `ENG-123`)
+1. Use linear-cli to fetch the issue:
+   ```bash
+   linear issue view ENG-123
+   ```
 2. Extract: title, description, state, priority, labels, assignee
 3. On success: Summarize the issue context
-4. On failure: Warn user - "Couldn't fetch Linear issue. Linear MCP may not be configured. Continue without issue context?"
+4. On failure: Warn user - "Couldn't fetch Linear issue. Is linear-cli installed and authenticated? Continue without issue context?"
 
-Note: Tool names may vary by Linear MCP implementation. Common tools: `linear_search_issues`, `linear_create_issue`, `linear_update_issue`.
+Note: Run `linear issue view --help` to see available options.
 
 ### Update Session Context
 


### PR DESCRIPTION
## Summary

- Switch from Linear MCP to [linear-cli](https://github.com/schpet/linear-cli) for Linear integration
- ~5x less context cost (~2KB vs ~10KB)
- On-demand discovery via `--help` instead of loading all MCP tools upfront
- Bonus: git integration (branch creation from issues)

## Changes

- `commands/start.md` - Use `linear issue view` to fetch issues
- `commands/review.md` - Use `linear issue create` for findings
- `commands/archive.md` - Use `linear issue update` and `linear issue comment add`
- `commands/configure.md` - Update question text
- `README.md` - Updated install/auth instructions
- `CHANGELOG.md` - v0.9.2 with migration guide

## Test plan

- [x] Verified linear-cli auth works (`linear auth whoami`)
- [x] Tested `linear issue list` from GTM project
- [x] Tested `linear issue view GTMENG-420`
- [x] Verified create/update/comment syntax matches CLI help