### PR TITLE
feat: add /bonfire meta-skill as entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Works with Claude Code, OpenCode, Cursor, and other [Agent Skills](https://agent
 ```
 bonfire/
 ├── skills/                          # Agent Skills (universal)
+│   ├── bonfire/SKILL.md             # Meta-skill: entry point & help
 │   ├── bonfire-start/SKILL.md
 │   ├── bonfire-end/SKILL.md
 │   ├── bonfire-spec/SKILL.md
@@ -40,6 +41,7 @@ bonfire/
 
 | Skill | Description |
 |-------|-------------|
+| `/bonfire` | **Entry point** - shows all commands and getting started guide |
 | `/bonfire-start` | Start session, read context, scaffold if needed |
 | `/bonfire-end` | End session, update context |
 | `/bonfire-spec <topic>` | Create implementation spec |

--- a/skills/bonfire/SKILL.md
+++ b/skills/bonfire/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: bonfire
+description: Session context persistence for AI coding - save your progress at the bonfire. Use this skill when the user asks about bonfire, wants to see available commands, or needs help getting started.
+license: MIT
+allowed-tools: Read
+metadata:
+  author: vieko
+  version: "3.0.0"
+---
+
+# Bonfire
+
+Session context persistence for AI coding. Save your progress at the bonfire.
+
+## Quick Start
+
+```
+/bonfire-start    Start a session (reads context, sets up if needed)
+/bonfire-end      End session (updates context, runs health check)
+```
+
+## All Commands
+
+| Command | Description |
+|---------|-------------|
+| `/bonfire-start` | Start a session - reads context, scaffolds `.bonfire/` if needed |
+| `/bonfire-end` | End session - updates context, syncs tasks, runs garbage detection |
+| `/bonfire-spec <topic>` | Create an implementation spec for a feature |
+| `/bonfire-document <topic>` | Create reference documentation |
+| `/bonfire-review` | Review current work for blindspots and improvements |
+| `/bonfire-review-pr <number>` | Review a GitHub PR and post inline comments |
+| `/bonfire-archive` | Archive completed work to reduce context size |
+| `/bonfire-configure` | Change project settings (locations, git strategy, Linear) |
+| `/bonfire-strategic <type> <topic>` | Create RFC, PRD, or POC documents |
+
+## Passive Triggers
+
+These skills activate automatically based on context:
+
+| Skill | Triggers When |
+|-------|---------------|
+| `bonfire-context` | User asks about previous sessions, decisions, or "what we did last time" |
+| `bonfire-archive-suggest` | PR is merged or work is completed |
+
+## Session Workflow
+
+```
+┌─────────────────┐
+│ /bonfire-start  │  Read context, understand state
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│   Do work...    │  Code, spec, review, document
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  /bonfire-end   │  Save progress, update context
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ /bonfire-archive│  (When work is merged/complete)
+└─────────────────┘
+```
+
+## Installation
+
+```bash
+npx skills add vieko/bonfire --all
+```
+
+## Session Context
+
+All context is stored in `.bonfire/` at your project root:
+
+```
+.bonfire/
+├── index.md      # Main session context
+├── config.json   # Settings
+├── specs/        # Implementation specs
+├── docs/         # Documentation
+└── archive/      # Completed sessions
+```
+
+## Getting Started
+
+Run `/bonfire-start` to begin. If `.bonfire/` doesn't exist, it will guide you through setup.


### PR DESCRIPTION
## Summary

- Adds `/bonfire` meta-skill that serves as the entry point for the skill collection
- Shows all available commands, passive triggers, and workflow diagram
- Provides getting started guide for new users

## Why

Currently bonfire has 11 skills that are tracked separately. Users need to know the specific command names. This meta-skill:

1. **Discoverability** - Run `/bonfire` to see everything available
2. **Onboarding** - New users get a quick start guide
3. **Documentation** - Single place for workflow overview

## Long-term Solution

Also drafted a proposal for skill packages in skills.sh that would allow tracking bonfire as a single unit. See `.bonfire/docs/skill-packages-proposal.md` (not committed, local only).

## Usage

```
> /bonfire

# Bonfire

## Quick Start
/bonfire-start    Start a session
/bonfire-end      End session

## All Commands
[table of all 9 commands + 2 passive triggers]
```

## Test plan

- [ ] Run `/bonfire` and verify help output displays
- [ ] Verify all commands are listed accurately
- [ ] Check workflow diagram renders correctly